### PR TITLE
Allow setting of numeric env variables

### DIFF
--- a/lib/tomafro/deploy.rb
+++ b/lib/tomafro/deploy.rb
@@ -22,7 +22,7 @@ Capistrano::Configuration.instance(:must_exist).load do
   # directory.  The default is `/var/apps/#{application}`.
   set(:deploy_to)   { "/var/apps/#{application}" }
 
-  # Each release is marked by a unique tag, generated with the current timestamp.  Whil this can be
+  # Each release is marked by a unique tag, generated with the current timestamp.  While this can be
   # changed, it's not recommended, as the sort order of the tag names is important; later tags must
   # be listed after earlier tags.
   set(:release_tag) { "#{Time.now.utc.strftime("%Y%m%d%H%M%S")}"}

--- a/lib/tomafro/deploy/env.rb
+++ b/lib/tomafro/deploy/env.rb
@@ -19,7 +19,7 @@ Capistrano::Configuration.instance(:must_exist).load do
 
     def write_environment(env)
       env.keys.sort.collect do |v|
-        "#{v}=#{env[v]}" unless env[v].nil? || env[v].empty?
+        "#{v}=#{env[v]}" unless env[v].nil? || env[v] == ""
       end.compact.join("\n")
     end
 


### PR DESCRIPTION
I'm presuming that the hope here was setting an empty string would remove the variable. Unfortunately, Fixnum doesn't respond to empty?
