### PR TITLE
Prevent ^M characters from entering the env file

### DIFF
--- a/index.rb
+++ b/index.rb
@@ -43,5 +43,11 @@
 # For (limited) compatability with other existing recipes, see
 # [compatibility](lib/tomafro/deploy/compatibility.html)
 
+# ### Deployment target ###
+
+# These recipes have been run successful against Ubuntu.
+
+# The application should be run as the application user; if using Apache and Passenger, you should set the `PassengerDefaultUser` directive to be the same as the `application_user`.
+
 # The code is available [on github](http://github.com/tomafro/tomafro-deploy) and released under the
 # [MIT License](https://github.com/tomafro/tomafro-deploy/blob/master/LICENSE)

--- a/lib/tomafro/deploy/env.rb
+++ b/lib/tomafro/deploy/env.rb
@@ -7,7 +7,7 @@ Capistrano::Configuration.instance(:must_exist).load do
         if deployed_file_exists?(environment_file)
           capture("cat #{environment_file}").split("\n").inject({}) do |env, line|
             if line =~ /\A([A-Za-z_]+)=(.*)\z/
-              env[$1] = $2
+              env[$1] = $2.strip
             end
             env
           end


### PR DESCRIPTION
This happens when you write back the env after its been read from the server.
