### PR TITLE
`cap env` rather than `cap env:read` ?

### DIFF
--- a/lib/tomafro/deploy/env.rb
+++ b/lib/tomafro/deploy/env.rb
@@ -33,7 +33,7 @@ Capistrano::Configuration.instance(:must_exist).load do
       end.compact.join("\n")
     end
 
-    task :read do
+    task :default do
       puts write_environment(current_environment)
     end
 


### PR DESCRIPTION
This is a bit more like Heroku.
