### PR TITLE
Mocha::Expectation#in_sequence with no Mocha::Sequence has no effect.

### DIFF
--- a/spec/tasks/bootstrap_spec.rb
+++ b/spec/tasks/bootstrap_spec.rb
@@ -10,6 +10,10 @@ describe Recap::Tasks::Bootstrap do
     config.bootstrap
   end
 
+  let :commands do
+    sequence('commands')
+  end
+
   before do
     Recap::Tasks::Bootstrap.load_into(config)
   end
@@ -17,8 +21,8 @@ describe Recap::Tasks::Bootstrap do
   describe 'Tasks' do
     describe 'bootstrap' do
       it 'runs bootsrap:application and bootstrap:user tasks' do
-        namespace.expects(:application).in_sequence
-        namespace.expects(:user).in_sequence
+        namespace.expects(:application).in_sequence(commands)
+        namespace.expects(:user).in_sequence(commands)
         config.find_and_execute_task('bootstrap')
       end
     end

--- a/spec/tasks/deploy_spec.rb
+++ b/spec/tasks/deploy_spec.rb
@@ -9,6 +9,10 @@ describe Recap::Tasks::Deploy do
     config.deploy
   end
 
+  let :commands do
+    sequence('commands')
+  end
+
   before do
     Recap::Tasks::Deploy.load_into(config)
   end
@@ -117,9 +121,9 @@ describe Recap::Tasks::Deploy do
 
     describe 'deploy:clone_code' do
       it 'creates deploy_to dir, ensures it\'s group writable, then clones the repository into it' do
-        namespace.expects(:as_app).with('mkdir -p ' + deploy_to, '~').in_sequence
-        namespace.expects(:as_app).with('chmod g+rw ' + deploy_to).in_sequence
-        namespace.expects(:git).with('clone ' + repository + ' .').in_sequence
+        namespace.expects(:as_app).with('mkdir -p ' + deploy_to, '~').in_sequence(commands)
+        namespace.expects(:as_app).with('chmod g+rw ' + deploy_to).in_sequence(commands)
+        namespace.expects(:git).with('clone ' + repository + ' .').in_sequence(commands)
         config.find_and_execute_task('deploy:clone_code')
       end
     end
@@ -129,9 +133,9 @@ describe Recap::Tasks::Deploy do
         env = stub('env')
         config.stubs(:env).returns(env)
         env.expects('set')
-        namespace.expects(:update_code).in_sequence
-        namespace.expects(:tag).in_sequence
-        namespace.expects(:restart).in_sequence
+        namespace.expects(:update_code).in_sequence(commands)
+        namespace.expects(:tag).in_sequence(commands)
+        namespace.expects(:restart).in_sequence(commands)
         config.find_and_execute_task('deploy')
       end
 
@@ -157,8 +161,8 @@ describe Recap::Tasks::Deploy do
     describe 'deploy:update_code' do
       it 'fetches latest changes, then resets to repository branch' do
         config.set :branch, 'release-branch'
-        namespace.expects(:git).with('fetch').in_sequence
-        namespace.expects(:git).with('reset --hard origin/release-branch').in_sequence
+        namespace.expects(:git).with('fetch').in_sequence(commands)
+        namespace.expects(:git).with('reset --hard origin/release-branch').in_sequence(commands)
         namespace.find_and_execute_task('deploy:update_code')
       end
     end
@@ -179,9 +183,9 @@ describe Recap::Tasks::Deploy do
       it 'deletes latest tag, resets to previous tag and restarts' do
         config.stubs(:latest_tag).returns('release-2')
         config.stubs(:latest_tag_from_repository).returns('release-1')
-        namespace.expects(:git).with('tag -d release-2').in_sequence
-        namespace.expects(:git).with('reset --hard release-1').in_sequence
-        namespace.expects(:restart).in_sequence
+        namespace.expects(:git).with('tag -d release-2').in_sequence(commands)
+        namespace.expects(:git).with('reset --hard release-1').in_sequence(commands)
+        namespace.expects(:restart).in_sequence(commands)
         namespace.find_and_execute_task('deploy:rollback')
       end
 

--- a/spec/tasks/foreman_spec.rb
+++ b/spec/tasks/foreman_spec.rb
@@ -13,6 +13,10 @@ describe Recap::Tasks::Foreman do
     'path/to/deploy/to'
   end
 
+  let :commands do
+    sequence('commands')
+  end
+
   before do
     config.set :application, 'example-app'
     config.set :application_user, 'example-app-user'
@@ -95,9 +99,9 @@ describe Recap::Tasks::Foreman do
     describe 'foreman:export' do
       it 'runs the foreman export command, then moves the exported files to the export location' do
         namespace.stubs(:deployed_file_exists?).with(config.procfile).returns(true)
-        namespace.expects(:as_app).with(config.foreman_export_command).in_sequence
-        namespace.expects(:sudo).with("rm -f #{config.foreman_export_location}/#{config.application}*").in_sequence
-        namespace.expects(:sudo).with("cp #{config.foreman_tmp_location}/* #{config.foreman_export_location}").in_sequence
+        namespace.expects(:as_app).with(config.foreman_export_command).in_sequence(commands)
+        namespace.expects(:sudo).with("rm -f #{config.foreman_export_location}/#{config.application}*").in_sequence(commands)
+        namespace.expects(:sudo).with("cp #{config.foreman_tmp_location}/* #{config.foreman_export_location}").in_sequence(commands)
         config.find_and_execute_task('foreman:export')
       end
 


### PR DESCRIPTION
A number of tests setup expectations and attempt to constrain them to
occur one after the other using Mocha::Expectation#in_sequence, but
without supplying any instances of Mocha::Sequence. This means that the
expectations are not constrained to occur in the specified order.

I've added a sequence so that the intended constraint is enforced.

I've also added a Mocha issue [1] to highlight this potential for confusion.

[1] https://github.com/floehopper/mocha/issues/79
