### PR TITLE
Use expectations to check for calls to Kernel#abort.

### DIFF
--- a/spec/tasks/bundler_spec.rb
+++ b/spec/tasks/bundler_spec.rb
@@ -94,9 +94,9 @@ describe Recap::Tasks::Bundler do
       it 'aborts with warning if Gemfile exists but Gemfile.lock doesn\'t' do
         namespace.stubs(:deployed_file_exists?).with(config.bundle_gemfile).returns(true)
         namespace.stubs(:deployed_file_exists?).with(config.bundle_gemfile_lock).returns(false)
-        lambda do
-          namespace.find_and_execute_task('bundle:install')
-        end.should raise_error(SystemExit, 'Gemfile found without Gemfile.lock.  The Gemfile.lock should be committed to the project repository')
+        expected_message = 'Gemfile found without Gemfile.lock.  The Gemfile.lock should be committed to the project repository'
+        namespace.install.expects(:abort).with(expected_message)
+        namespace.find_and_execute_task('bundle:install')
       end
     end
 

--- a/spec/tasks/deploy_spec.rb
+++ b/spec/tasks/deploy_spec.rb
@@ -24,17 +24,15 @@ describe Recap::Tasks::Deploy do
   describe 'Settings' do
     describe '#application' do
       it 'exits if accessed before being set' do
-        lambda do
-          config.application
-        end.should raise_error(SystemExit)
+        namespace.expects(:abort).with(regexp_matches(/You must set the name of your application in your Capfile/))
+        config.application
       end
     end
 
     describe '#repository' do
       it 'exits if accessed before being set' do
-        lambda do
-          config.repository
-        end.should raise_error(SystemExit)
+        namespace.expects(:abort).with(regexp_matches(/You must set the git respository location in your Capfile/))
+        config.repository
       end
     end
 
@@ -187,9 +185,8 @@ describe Recap::Tasks::Deploy do
 
       it 'aborts if no tag has been deployed' do
         config.stubs(:latest_tag).returns(nil)
-        lambda do
-          namespace.find_and_execute_task('deploy:rollback')
-        end.should raise_error(SystemExit, 'This app is not currently deployed')
+        namespace.rollback.expects(:abort).with('This app is not currently deployed')
+        namespace.find_and_execute_task('deploy:rollback')
       end
     end
 


### PR DESCRIPTION
Previously we were checking that a SystemExit exception was being
raised, but this meant that the error message was send to stderr.

Note that you have to be careful to set the expectation on the correct
capistrano namespace object, which makes this a little awkward, but I
think it's ok.

This should fix #30.
