### PR TITLE
Provide a useful error message if `bundle` is not available and will be required later.

### DIFF
--- a/lib/recap.rb
+++ b/lib/recap.rb
@@ -90,6 +90,7 @@ module Recap
     autoload :Deploy, 'recap/tasks/deploy'
     autoload :Env, 'recap/tasks/env'
     autoload :Foreman, 'recap/tasks/foreman'
+    autoload :Preflight, 'recap/tasks/preflight'
 
     # Deploying [Rails](recap/recipes/rails.html) requires a bit of extra work to ensure that migrations and run and
     # assets are generated. These can be included by simply requiring `recap/recipes/rails` instead of `recap/recipes/static`

--- a/lib/recap/support/capistrano_extensions.rb
+++ b/lib/recap/support/capistrano_extensions.rb
@@ -58,6 +58,10 @@ module Recap::Support::CapistranoExtensions
     capture("#{command} > /dev/null 2>&1; echo $?").strip
   end
 
+  def exit_code_as_app(command, pwd = deploy_to)
+    capture(%|sudo -p 'sudo password: ' su - #{application_user} -c 'cd #{pwd} && #{command} > /dev/null 2>&1'; echo $?|).strip
+  end
+
   # Find the latest tag from the repository.  As `git tag` returns tags in order, and our release
   # tags are timestamps, the latest tag will always be the last in the list.
   def latest_tag_from_repository

--- a/lib/recap/tasks/bundler.rb
+++ b/lib/recap/tasks/bundler.rb
@@ -48,8 +48,8 @@ module Recap::Tasks::Bundler
     end
 
     task :check_installed do
-      if exit_code('bundle --version').strip != "0"
-        abort 'Bundler was not found on the remote machine.  Please check you have bundler installed.'
+      if exit_code_as_app('bundle --version') != "0"
+        abort "The application user '#{application_user}' cannot execute `bundle`.  Please check you have bundler installed."
       end
     end
     after 'preflight:check', 'bundle:check_installed'

--- a/lib/recap/tasks/bundler.rb
+++ b/lib/recap/tasks/bundler.rb
@@ -47,6 +47,13 @@ module Recap::Tasks::Bundler
       end
     end
 
+    task :check_installed do
+      if exit_code('bundle --version').strip != "0"
+        abort 'Bundler was not found on the remote machine.  Please check you have bundler installed.'
+      end
+    end
+    after 'preflight:check', 'bundle:check_installed'
+
     # To install the bundle automatically each time the code is updated or cloned, hooks are added to
     # the `deploy:clone_code` and `deploy:update_code` tasks.
     after 'deploy:clone_code', 'bundle:install:if_changed'

--- a/spec/tasks/bundler_spec.rb
+++ b/spec/tasks/bundler_spec.rb
@@ -124,14 +124,18 @@ describe Recap::Tasks::Bundler do
     end
 
     describe 'bundle:check_installed' do
+      before do
+        config.set(:application_user, 'fred')
+      end
+
       it 'checks to see whether bundler is installed' do
-        namespace.expects(:exit_code).with('bundle --version').returns("0")
+        namespace.expects(:exit_code_as_app).with('bundle --version').returns("0")
         config.find_and_execute_task('bundle:check_installed')
       end
 
       it 'aborts with explanation if bundler command fails' do
-        namespace.stubs(:exit_code).returns("1")
-        namespace.expects(:abort).with('Bundler was not found on the remote machine.  Please check you have bundler installed.')
+        namespace.stubs(:exit_code_as_app).returns("1")
+        namespace.expects(:abort).with("The application user 'fred' cannot execute `bundle`.  Please check you have bundler installed.")
         config.find_and_execute_task('bundle:check_installed')
       end
     end

--- a/spec/tasks/bundler_spec.rb
+++ b/spec/tasks/bundler_spec.rb
@@ -122,5 +122,32 @@ describe Recap::Tasks::Bundler do
         config.find_and_execute_task('bundle:install:if_changed')
       end
     end
+
+    describe 'bundle:check_installed' do
+      it 'checks to see whether bundler is installed' do
+        namespace.expects(:exit_code).with('bundle --version').returns("0")
+        config.find_and_execute_task('bundle:check_installed')
+      end
+
+      it 'aborts with explanation if bundler command fails' do
+        namespace.stubs(:exit_code).returns("1")
+        namespace.expects(:abort).with('Bundler was not found on the remote machine.  Please check you have bundler installed.')
+        config.find_and_execute_task('bundle:check_installed')
+      end
+    end
+  end
+
+  describe 'Callbacks' do
+    describe 'bundle:check_installed' do
+      before do
+        Recap::Tasks::Preflight.load_into(config)
+      end
+
+      it 'runs after `preflight:check`' do
+        config.stubs(:find_and_execute_task)
+        config.expects(:find_and_execute_task).with('bundle:check_installed')
+        config.trigger :after, config.find_task('preflight:check')
+      end
+    end
   end
 end


### PR DESCRIPTION
We've added a preflight check that bundler is installed for the application user. This check should only occur if the recap bundler tasks have been loaded i.e. it should not occur if the "static" recap recipe is used.
