### PR TITLE
Ensure ~/.recap can be sourced from anywhere

### DIFF
--- a/lib/recap/tasks/bootstrap.rb
+++ b/lib/recap/tasks/bootstrap.rb
@@ -41,7 +41,7 @@ module Recap::Tasks::Bootstrap
       # a new copy with `export ` prefixed to each line, and sources this new copy.
       put_as_app %{
 if [ -s "$HOME/.env" ]; then
-  sed -e 's/\\r//g' -e 's/^/export /g' .env > .recap-env-export
+  sed -e 's/\\r//g' -e 's/^/export /g' $HOME/.env > $HOME/.recap-env-export
   . $HOME/.recap-env-export
 fi
       }, "#{application_home}/.recap"


### PR DESCRIPTION
Sourcing ~/.recap from outside the home directory fails to generate the
.recap-env-export file correctly because it expects to find .env in the
current directory.

This fix ensures we read ~/.env and generate ~/.recap-env-export
correctly.

I came across this problem when using the whenever gem to generate my
crontab.  It generate a command similar to /bin/bash -l -c 'my-command'
which I tried to run from the command line.  Running it in a directory
outside of ~ fails due to the problem mentioned above.  _NOTE_ The key
part of that command is '-l' which tells bash to load ~/.profile (among
other things).
