### PR TITLE
Handle edge case where a new migration does not change the schema

### DIFF
--- a/lib/recap/tasks/rails.rb
+++ b/lib/recap/tasks/rails.rb
@@ -30,7 +30,8 @@ module Recap::Tasks::Rails
       end
 
       task :migrate do
-        if deployed_file_exists?("db/schema.rb") && trigger_update?("db/schema.rb")
+        if deployed_file_exists?("db/schema.rb") &&
+          (trigger_update?("db/schema.rb") || trigger_update?("db/migrations/"))
           as_app './bin/rake db:migrate'
         end
       end

--- a/lib/recap/tasks/rails.rb
+++ b/lib/recap/tasks/rails.rb
@@ -30,8 +30,7 @@ module Recap::Tasks::Rails
       end
 
       task :migrate do
-        if deployed_file_exists?("db/schema.rb") &&
-          (trigger_update?("db/schema.rb") || trigger_update?("db/migrations/"))
+        if deployed_file_exists?("db/schema.rb") && trigger_update?("db/migrations/")
           as_app './bin/rake db:migrate'
         end
       end

--- a/spec/models/capistrano_extensions_spec.rb
+++ b/spec/models/capistrano_extensions_spec.rb
@@ -38,4 +38,35 @@ describe Recap::Support::CapistranoExtensions do
       config.edit_file('remote/path/to/file')
     end
   end
+
+  describe '#trigger_update?' do
+    context 'when forcing full deploy' do
+      before(:each) do
+        config.stubs(:force_full_deploy).returns(true)
+      end
+
+      it 'returns true' do
+        config.trigger_update?('path/to/file').should be_true
+      end
+    end
+
+    context 'when not forcing full deploy' do
+      before(:each) do
+        config.stubs(:force_full_deploy).returns(false)
+        config.stubs(:changed_files).returns(['path/to/changed/file', 'directory/containing/changed/file'])
+      end
+
+      it 'returns false for a file path which has not changed' do
+        config.trigger_update?('no/changes/here').should be_false
+      end
+
+      it 'returns true for a file path which has changed' do
+        config.trigger_update?('path/to/changed/file').should be_true
+      end
+
+      it 'returns true for a directory path which contains a changed file' do
+        config.trigger_update?('directory/containing/changed/').should be_true
+      end
+    end
+  end
 end

--- a/spec/tasks/rails_spec.rb
+++ b/spec/tasks/rails_spec.rb
@@ -54,9 +54,18 @@ describe Recap::Tasks::Rails do
         config.find_and_execute_task('rails:db:migrate')
       end
 
-      it 'does nothing if the schema has not changed' do
+      it 'runs migrations if migrations have changed' do
         namespace.stubs(:deployed_file_exists?).with('db/schema.rb').returns(true)
         namespace.stubs(:trigger_update?).with('db/schema.rb').returns(false)
+        namespace.stubs(:trigger_update?).with('db/migrations/').returns(true)
+        namespace.expects(:as_app).with('./bin/rake db:migrate')
+        config.find_and_execute_task('rails:db:migrate')
+      end
+
+      it 'does nothing if the schema and migrations have not changed' do
+        namespace.stubs(:deployed_file_exists?).with('db/schema.rb').returns(true)
+        namespace.stubs(:trigger_update?).with('db/schema.rb').returns(false)
+        namespace.stubs(:trigger_update?).with('db/migrations/').returns(false)
         namespace.expects(:as_app).never
         config.find_and_execute_task('rails:db:migrate')
       end

--- a/spec/tasks/rails_spec.rb
+++ b/spec/tasks/rails_spec.rb
@@ -47,24 +47,15 @@ describe Recap::Tasks::Rails do
     end
 
     describe 'rails:db:migrate' do
-      it 'runs migrations if the schema has changed' do
-        namespace.stubs(:deployed_file_exists?).with('db/schema.rb').returns(true)
-        namespace.stubs(:trigger_update?).with('db/schema.rb').returns(true)
-        namespace.expects(:as_app).with('./bin/rake db:migrate')
-        config.find_and_execute_task('rails:db:migrate')
-      end
-
       it 'runs migrations if migrations have changed' do
         namespace.stubs(:deployed_file_exists?).with('db/schema.rb').returns(true)
-        namespace.stubs(:trigger_update?).with('db/schema.rb').returns(false)
         namespace.stubs(:trigger_update?).with('db/migrations/').returns(true)
         namespace.expects(:as_app).with('./bin/rake db:migrate')
         config.find_and_execute_task('rails:db:migrate')
       end
 
-      it 'does nothing if the schema and migrations have not changed' do
+      it 'does nothing if the migrations have not changed' do
         namespace.stubs(:deployed_file_exists?).with('db/schema.rb').returns(true)
-        namespace.stubs(:trigger_update?).with('db/schema.rb').returns(false)
         namespace.stubs(:trigger_update?).with('db/migrations/').returns(false)
         namespace.expects(:as_app).never
         config.find_and_execute_task('rails:db:migrate')

--- a/spec/tasks/rails_spec.rb
+++ b/spec/tasks/rails_spec.rb
@@ -63,7 +63,6 @@ describe Recap::Tasks::Rails do
 
       it 'does nothing if the schema does not exist' do
         namespace.stubs(:deployed_file_exists?).with('db/schema.rb').returns(false)
-        namespace.stubs(:trigger_update?).with('db/schema.rb').returns(true)
         namespace.expects(:as_app).never
         config.find_and_execute_task('rails:db:migrate')
       end


### PR DESCRIPTION
This can occur when a migrations makes changes to data rather than table structure and is run after another migration has been added with a later creation time.
