### PR TITLE
Allow deploys for projects using sql schema_format.

### DIFF
--- a/lib/recap/tasks/rails.rb
+++ b/lib/recap/tasks/rails.rb
@@ -26,11 +26,13 @@ module Recap::Tasks::Rails
       task :load_schema do
         if deployed_file_exists?("db/schema.rb")
           as_app_once './bin/rake db:create db:schema:load'
+        elsif deployed_file_exists?("db/structure.sql")
+          as_app_once './bin/rake db:create db:structure:load'
         end
       end
 
       task :migrate do
-        if deployed_file_exists?("db/schema.rb") && trigger_update?("db/")
+        if (deployed_file_exists?("db/schema.rb") || deployed_file_exists?("db/structure.sql")) && trigger_update?("db/")
           as_app_once './bin/rake db:migrate'
         end
       end


### PR DESCRIPTION
For a rails project using database-specific constraints, the file
describing the state of the database is db/structure.sql instead of
db/schema.rb. This allows the existing tasks to use either file when
creating or migrating a database.

see http://guides.rubyonrails.org/migrations.html#schema-dumping-and-you
