### PR TITLE
Only clone if directory is not already a git repo

### DIFF
--- a/lib/recap/tasks/deploy.rb
+++ b/lib/recap/tasks/deploy.rb
@@ -86,7 +86,7 @@ module Recap::Tasks::Deploy
       as_app "mkdir -p #{deploy_to}", "~"
       as_app "chmod g+rw #{deploy_to}"
       # Then clone the code and change to the given branch
-      git "clone #{repository} ."
+      run "if [ ! -d #{deploy_to}/.git ]; then umask 002 && sg #{application_group} -c \"git clone #{repository} #{deploy_to}\"; fi"
       git "reset --hard origin/#{branch}"
     end
 


### PR DESCRIPTION
When adding machines to a cluster, one might presume the `bootstrap` and `deploy:setup` tasks are idempotent (as I think they are in cap).
This means the clone step fails on existing machines, causing the rollback operation to kick in and all machines to have the app folder removed.
Duplicates a little of the logic in your git helper
