### PR TITLE
Only attempt to clone from repo when .git directory does not exist

### DIFF
--- a/lib/recap/support/capistrano_extensions.rb
+++ b/lib/recap/support/capistrano_extensions.rb
@@ -68,6 +68,11 @@ module Recap::Support::CapistranoExtensions
     exit_code("cd #{root_path} && [ -f #{path} ]") == "0"
   end
 
+  # Does the given directory exist within the deployment directory?
+  def deployed_dir_exists?(path, root_path = deploy_to)
+    exit_code("cd #{root_path} && [ -d #{path} ]") == "0"
+  end
+
   # Has the given path been created or changed since the previous deployment?  During the first
   # successful deployment this will always return true if the file exists.
   def deployed_file_changed?(path)

--- a/lib/recap/tasks/deploy.rb
+++ b/lib/recap/tasks/deploy.rb
@@ -86,8 +86,10 @@ module Recap::Tasks::Deploy
       as_app "mkdir -p #{deploy_to}", "~"
       as_app "chmod g+rw #{deploy_to}"
       # Then clone the code and change to the given branch
-      git "clone #{repository} ."
-      git "reset --hard origin/#{branch}"
+      unless deployed_dir_exists?(".git")
+        git "clone #{repository} ."
+        git "reset --hard origin/#{branch}"
+      end
     end
 
     # The `deploy` task ensures the environment is set, updates the application code,

--- a/spec/tasks/deploy_spec.rb
+++ b/spec/tasks/deploy_spec.rb
@@ -159,6 +159,7 @@ describe Recap::Tasks::Deploy do
 
         namespace.expects(:as_app).with('mkdir -p ' + deploy_to, '~').in_sequence(commands)
         namespace.expects(:as_app).with('chmod g+rw ' + deploy_to).in_sequence(commands)
+        namespace.expects(:deployed_dir_exists?).with('.git').in_sequence(commands)
         namespace.expects(:git).with('clone ' + repository + ' .').in_sequence(commands)
         namespace.expects(:git).with('reset --hard origin/given-branch').in_sequence(commands)
         config.find_and_execute_task('deploy:clone_code')


### PR DESCRIPTION
If `deploy:setup` is run twice before a second deploy is done, the app is removed and destroyed and a complete redeploy is necessary. This will handle cloning the repository twice.

Fixes #92
