### PR TITLE
Handle regular expressions in CapistranoExtensions#trigger_update?

### DIFF
--- a/lib/recap/support/capistrano_extensions.rb
+++ b/lib/recap/support/capistrano_extensions.rb
@@ -89,7 +89,13 @@ module Recap::Support::CapistranoExtensions
   end
 
   def trigger_update?(path)
-    force_full_deploy || changed_files.detect {|p| p[0, path.length] == path}
+    force_full_deploy || changed_files.detect {|p|
+      if path.is_a?(Regexp)
+        p =~ path
+      else
+        p[0, path.length] == path
+      end
+    }
   end
 
   def claim_lock(message)

--- a/spec/models/capistrano_extensions_spec.rb
+++ b/spec/models/capistrano_extensions_spec.rb
@@ -67,6 +67,22 @@ describe Recap::Support::CapistranoExtensions do
       it 'returns true for a directory path which contains a changed file' do
         config.trigger_update?('directory/containing/changed/').should be_true
       end
+
+      it 'returns true for a regex that matches a changed file' do
+        config.trigger_update?(/^path\/to\/changed\/file/).should be_true
+      end
+
+      it 'returns false for a regex that does not match a changed file' do
+        config.trigger_update?(/^no\/changes\/here/).should be_false
+      end
+
+      it 'returns false for a regex matching a directory with no changes' do
+        config.trigger_update?(/^no\/changes\//).should be_false
+      end
+
+      it 'returns true for a regex matching a directory with changes' do
+        config.trigger_update?(/^path\/to\//).should be_true
+      end
     end
   end
 end


### PR DESCRIPTION
We have a Rails app serving multiple sites, each with their own assets placed under `app/sites/<domain>/assets`. Adding these to `:asset_precompilation_triggers` using a regular expression is much simpler than adding each site as a string. 
