### PR TITLE
Fix documentation published to gofreerange.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ The source code is available [on Github](https://github.com/freerange/recap).
 
 This defaults to publishing to gofreerange.com but that can be customised by setting the `RECAP_DOCS_HOST` environment variable.
 
-    $ rake doc publish
+The `fl-rocco` gem relies on the `pygments` Python package being installed (`pip install pygments`); more specifically the `pygmentize` binary being available in the `PATH`.
+
+    $ bundle exec rake doc publish
 
 *NOTE*. The recap docs rely on a rocco.css file being available at `#{RECAP_DOCS_HOST}/stylesheets/rocco.css`. This was [added to our site in e41bac][e41bac]
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ The source code is available [on Github](https://github.com/freerange/recap).
     `$ bundle exec cucumber`
 
 
+## Publishing documentation
+
+This defaults to publishing to gofreerange.com but that can be customised by setting the `RECAP_DOCS_HOST` environment variable.
+
+    $ rake doc publish
+
+*NOTE*. The recap docs rely on a rocco.css file being available at `#{RECAP_DOCS_HOST}/stylesheets/rocco.css`. This was [added to our site in e41bac][e41bac]
+
+[e41bac]: https://github.com/freerange/site/commit/e41bac9954eddd2ca9dda0f8d034bb3f8ac77bd3
+
+
 ## Credits
 
 Recap was written by [Tom Ward](http://tomafro.net) and the other members of [Go Free Range](http://gofreerange.com).

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ task :doc do
   FileUtils.cd('lib') do
     files = Dir['**/*.rb']
     files.each do |source_file|
-      rocco = Rocco.new(source_file, files.to_a, {:stylesheet => "http://#{RECAP_DOCS_HOST}/stylesheets/rocco.css"})
+      rocco = Rocco.new(source_file, files.to_a, {:stylesheet => "https://#{RECAP_DOCS_HOST}/stylesheets/rocco.css"})
       dest_file = '../doc/' + source_file.sub(Regexp.new("#{File.extname(source_file)}$"), '.html')
       FileUtils.mkdir_p(File.dirname(dest_file))
       File.open(dest_file, 'wb') { |fd| fd.write(rocco.to_html) }

--- a/Rakefile
+++ b/Rakefile
@@ -2,12 +2,14 @@ require 'bundler/gem_tasks'
 require 'rocco/tasks'
 require 'rspec/core/rake_task'
 
+RECAP_DOCS_HOST = ENV['RECAP_DOCS_HOST'] || 'gofreerange.com'
+
 desc 'build docs'
 task :doc do
   FileUtils.cd('lib') do
     files = Dir['**/*.rb']
     files.each do |source_file|
-      rocco = Rocco.new(source_file, files.to_a, {:stylesheet => "http://gofreerange.com/stylesheets/rocco.css"})
+      rocco = Rocco.new(source_file, files.to_a, {:stylesheet => "http://#{RECAP_DOCS_HOST}/stylesheets/rocco.css"})
       dest_file = '../doc/' + source_file.sub(Regexp.new("#{File.extname(source_file)}$"), '.html')
       FileUtils.mkdir_p(File.dirname(dest_file))
       File.open(dest_file, 'wb') { |fd| fd.write(rocco.to_html) }
@@ -23,7 +25,7 @@ end
 desc 'publish docs'
 task :publish do
   path = "/home/freerange/docs/recap"
-  system %{ssh gofreerange.com "sudo rm -fr #{path} && mkdir -p #{path}" && scp -r doc/* gofreerange.com:#{path}}
+  system %{ssh #{RECAP_DOCS_HOST} "sudo rm -fr #{path} && mkdir -p #{path}" && scp -r doc/* #{RECAP_DOCS_HOST}:#{path}}
 end
 
 RSpec::Core::RakeTask.new(:spec) do |t|


### PR DESCRIPTION
I just noticed the docs were broken at https://gofreerange.com/recap/docs/. This fixes them.

This PR also includes a couple of related changes @chrisroos made years ago which haven't made it into the upstream repo.

@tomafro Would you be open to the idea of moving these docs back to GitHub Pages on the canonical repo in your GitHub account? We're in the process of simplifying our hosting requirements so we no longer need a Linode VPS and doing this would help us.